### PR TITLE
Rust Version Updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-skyline = "0.2.1"
+skyline = { git = "https://github.com/ultimate-research/skyline-rs" }
 smash_macro = { path = "./smash-macro" }
 bitflags = "1.3.2"
 hash40 = { git = "https://github.com/BenHall-7/hash40-rs" }

--- a/src/cpp/simd.rs
+++ b/src/cpp/simd.rs
@@ -1,20 +1,14 @@
 #[repr(simd)]
 pub struct Vector2 {
-    pub x: f32,
-    pub y: f32,
+    pub vec: [f32; 2]
 }
 
 #[repr(simd)]
 pub struct Vector3 {
-    pub x: f32,
-    pub y: f32,
-    pub z: f32,
+    pub vec: [f32; 3]
 }
 
 #[repr(simd)]
 pub struct Vector4 {
-    pub x: f32,
-    pub y: f32,
-    pub z: f32,
-    pub w: f32,
+    pub vec: [f32; 4]
 }

--- a/src/lib_impl/rect.rs
+++ b/src/lib_impl/rect.rs
@@ -68,10 +68,10 @@ impl Into<lib::L2CValue> for Rect {
 impl From<cpp::simd::Vector4> for Rect {
     fn from(other: cpp::simd::Vector4) -> Self {
         Rect {
-            left: other.x,
-            right: other.y,
-            top: other.z,
-            bottom: other.w
+            left: other.vec[0],
+            right: other.vec[1],
+            top: other.vec[2],
+            bottom: other.vec[3]
         }
     }
 }
@@ -79,10 +79,7 @@ impl From<cpp::simd::Vector4> for Rect {
 impl Into<cpp::simd::Vector4> for Rect {
     fn into(self) -> cpp::simd::Vector4 {
         cpp::simd::Vector4 {
-            x: self.left,
-            y: self.right,
-            z: self.top,
-            w: self.bottom
+            vec: [self.left, self.right, self.top, self.bottom]
         }
     }
 }

--- a/src/phx/vector.rs
+++ b/src/phx/vector.rs
@@ -69,8 +69,8 @@ impl fmt::Display for Vector2f {
 impl From<cpp::simd::Vector2> for Vector2f {
     fn from(other: cpp::simd::Vector2) -> Self {
         Self {
-            x: other.x,
-            y: other.y,
+            x: other.vec[0],
+            y: other.vec[1],
         }
     }
 }
@@ -78,8 +78,7 @@ impl From<cpp::simd::Vector2> for Vector2f {
 impl Into<cpp::simd::Vector2> for Vector2f {
     fn into(self) -> cpp::simd::Vector2 {
         cpp::simd::Vector2 {
-            x: self.x,
-            y: self.y,
+            vec: [self.x, self.y]
         }
     }
 }
@@ -230,9 +229,9 @@ impl Into<lib::L2CValue> for Vector3f {
 impl From<cpp::simd::Vector3> for Vector3f {
     fn from(other: cpp::simd::Vector3) -> Self {
         Self {
-            x: other.x,
-            y: other.y,
-            z: other.z,
+            x: other.vec[0],
+            y: other.vec[1],
+            z: other.vec[2],
         }
     }
 }
@@ -240,9 +239,7 @@ impl From<cpp::simd::Vector3> for Vector3f {
 impl Into<cpp::simd::Vector3> for Vector3f {
     fn into(self) -> cpp::simd::Vector3 {
         cpp::simd::Vector3 {
-            x: self.x,
-            y: self.y,
-            z: self.z,
+            vec: [self.x, self.y, self.z]
         }
     }
 }
@@ -394,10 +391,10 @@ impl Into<lib::L2CValue> for Vector4f {
 impl From<cpp::simd::Vector4> for Vector4f {
     fn from(other: cpp::simd::Vector4) -> Self {
         Self {
-            x: other.x,
-            y: other.y,
-            z: other.z,
-            w: other.w,
+            x: other.vec[0],
+            y: other.vec[1],
+            z: other.vec[2],
+            w: other.vec[3],
         }
     }
 }
@@ -405,10 +402,7 @@ impl From<cpp::simd::Vector4> for Vector4f {
 impl Into<cpp::simd::Vector4> for Vector4f {
     fn into(self) -> cpp::simd::Vector4 {
         cpp::simd::Vector4 {
-            x: self.x,
-            y: self.y,
-            z: self.z,
-            w: self.w,
+            vec: [self.x, self.y, self.z, self.w]
         }
     }
 }


### PR DESCRIPTION
`skyline` now pulls from its repo instead of crates.io

simd vectors were changed due to changes in rust nightly.