### PR TITLE
update simd vectors again

### DIFF
--- a/src/cpp/simd.rs
+++ b/src/cpp/simd.rs
@@ -1,14 +1,71 @@
+#[derive(Clone, Copy)]
 #[repr(simd)]
 pub struct Vector2 {
     pub vec: [f32; 2]
 }
 
+impl Vector2 {
+    pub fn x(self) -> f32 {
+        unsafe {
+            core::intrinsics::simd::simd_extract(self, 0)
+        }
+    }
+    pub fn y(self) -> f32 {
+        unsafe {
+            core::intrinsics::simd::simd_extract(self, 1)
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
 #[repr(simd)]
 pub struct Vector3 {
     pub vec: [f32; 3]
 }
 
+impl Vector3 {
+    pub fn x(self) -> f32 {
+        unsafe {
+            core::intrinsics::simd::simd_extract(self, 0)
+        }
+    }
+    pub fn y(self) -> f32 {
+        unsafe {
+            core::intrinsics::simd::simd_extract(self, 1)
+        }
+    }
+    pub fn z(self) -> f32 {
+        unsafe {
+            core::intrinsics::simd::simd_extract(self, 2)
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
 #[repr(simd)]
 pub struct Vector4 {
     pub vec: [f32; 4]
+}
+
+impl Vector4 {
+    pub fn x(self) -> f32 {
+        unsafe {
+            core::intrinsics::simd::simd_extract(self, 0)
+        }
+    }
+    pub fn y(self) -> f32 {
+        unsafe {
+            core::intrinsics::simd::simd_extract(self, 1)
+        }
+    }
+    pub fn z(self) -> f32 {
+        unsafe {
+            core::intrinsics::simd::simd_extract(self, 2)
+        }
+    }
+    pub fn w(self) -> f32 {
+        unsafe {
+            core::intrinsics::simd::simd_extract(self, 3)
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 #![feature(simd_ffi)]
 #![feature(const_trait_impl)]
 #![feature(pointer_byte_offsets)]
+#![feature(core_intrinsics)]
 #![allow(incomplete_features)]
 #![allow(improper_ctypes)] // For simd
 #![allow(non_snake_case)]

--- a/src/lib_impl/rect.rs
+++ b/src/lib_impl/rect.rs
@@ -68,10 +68,10 @@ impl Into<lib::L2CValue> for Rect {
 impl From<cpp::simd::Vector4> for Rect {
     fn from(other: cpp::simd::Vector4) -> Self {
         Rect {
-            left: other.vec[0],
-            right: other.vec[1],
-            top: other.vec[2],
-            bottom: other.vec[3]
+            left: other.x(),
+            right: other.y(),
+            top: other.z(),
+            bottom: other.w()
         }
     }
 }

--- a/src/phx/vector.rs
+++ b/src/phx/vector.rs
@@ -69,8 +69,8 @@ impl fmt::Display for Vector2f {
 impl From<cpp::simd::Vector2> for Vector2f {
     fn from(other: cpp::simd::Vector2) -> Self {
         Self {
-            x: other.vec[0],
-            y: other.vec[1],
+            x: other.x(),
+            y: other.y(),
         }
     }
 }
@@ -229,9 +229,9 @@ impl Into<lib::L2CValue> for Vector3f {
 impl From<cpp::simd::Vector3> for Vector3f {
     fn from(other: cpp::simd::Vector3) -> Self {
         Self {
-            x: other.vec[0],
-            y: other.vec[1],
-            z: other.vec[2],
+            x: other.x(),
+            y: other.y(),
+            z: other.z(),
         }
     }
 }
@@ -391,10 +391,10 @@ impl Into<lib::L2CValue> for Vector4f {
 impl From<cpp::simd::Vector4> for Vector4f {
     fn from(other: cpp::simd::Vector4) -> Self {
         Self {
-            x: other.vec[0],
-            y: other.vec[1],
-            z: other.vec[2],
-            w: other.vec[3],
+            x: other.x(),
+            y: other.y(),
+            z: other.z(),
+            w: other.w(),
         }
     }
 }


### PR DESCRIPTION
The incoming cargo-skyline std update to Rust Nightly 1.95.0 (2.14.26) necessitates these changes to more easily get the values from simd vectors.

Not to be merged until the std is updated.